### PR TITLE
fix: don't run codeql on push, only PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@
 name: "CodeQL"
 
 'on':
-  push:
+  pull_request:
   schedule:
     - cron: '0 1 * * 1'
 
@@ -28,11 +28,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
-
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
codeql/GHA changed to only work on PRs (not on pushes). Update workflow
for that