### PR TITLE
use latest golangci-lint action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,10 +13,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v3.0.0
+        with:
+          go-version: 1.17
       - uses: actions/checkout@v2.4.0
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Required: the version of golangci-lint is required and must be
           # specified without patch version: we always use the latest patch
-          version: v1.31
+          version: v1.44


### PR DESCRIPTION
Add setup-go step to golangci-lint workflow

The latest version of golangci-lint-action doesn't setup go on it's own
anymore, so the upgrade isn't simple enough for dependabot to handle.